### PR TITLE
General Wrath Classic Updates + Fix Debug level bug + Fix open HP issue

### DIFF
--- a/ArcHUD3-classic-WOTLKC.toc
+++ b/ArcHUD3-classic-WOTLKC.toc
@@ -1,0 +1,39 @@
+## Interface: 30400
+## Title: ArcHUD3 Classic
+## Notes: Smooth combat HUD based on ArcHUD2
+## Author: nyyr, Nenie
+## SavedVariables: ArcHUD3DB
+## Version: @project-version@
+## X-Date: @project-date-iso@
+## X-Category: HUDs
+## X-WoWI-ID: 25227
+## X-Curse-Project-ID: 339870
+
+# Libraries
+embeds.xml
+
+# Locales
+Locales\Locales.xml
+
+# Core addon
+Core.lua
+Frames.xml
+Nameplates.lua
+BlizzardFrames.lua
+Utils.lua
+
+# Module core
+RingTemplate.xml
+ModuleCore.lua
+
+# Config
+Config.lua
+
+# Rings
+Rings\Rings.xml
+
+# Extensions
+#Extensions\Extensions.xml
+
+# Unit frames
+#UnitFrames\UnitFrames.xml

--- a/BlizzardFrames.lua
+++ b/BlizzardFrames.lua
@@ -12,7 +12,7 @@ function ArcHUD:HideBlizzardPlayer(show)
 		PetFrame:UnregisterAllEvents()
 		PetFrame:Hide()
 		
-		if not ArcHUD.classic then
+		if not ArcHUD.isClassicWoW or ArcHUD.isClassicTbc then
 			RuneFrame:Hide()
 		end
 	else
@@ -23,7 +23,7 @@ function ArcHUD:HideBlizzardPlayer(show)
 		PetFrame:RegisterAllEvents()
 		PetFrame_Update(PetFrame, true)
 		
-		if not ArcHUD.classic then
+		if not ArcHUD.isClassicWoW or ArcHUD.isClassicTbc then
 			local _, class = UnitClass("player")
 			if ( class == "DEATHKNIGHT" ) then
 				RuneFrame:Show()

--- a/Config.lua
+++ b/Config.lua
@@ -107,9 +107,10 @@ ArcHUD.configOptionsTableCmd = {
 				return debugLevels[ArcHUD:GetDebugLevel() or 4]
 			end,
 			set			= function(info, v)
-				if (v == 1) then 
+				if (v == 4) then
 					ArcHUD:SetDebugLevel(nil)
 					ArcHUD.db.profile.Debug = nil
+					ArcHUD:Printf(L["CMD_OPTS_DEBUG_SET"], "off")
 				else 
 					ArcHUD:SetDebugLevel(v)
 					ArcHUD.db.profile.Debug = v

--- a/Core.lua
+++ b/Core.lua
@@ -15,7 +15,8 @@ ArcHUD.authors = "nyyr, Nenie"
 -- Classic specifics
 ArcHUD.isClassicWoW = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
 ArcHUD.isClassicTbc = (WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC)
-ArcHUD.classic = ArcHUD.isClassicWoW or ArcHUD.isClassicTbc
+ArcHUD.isClassicWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
+ArcHUD.classic = ArcHUD.isClassicWoW or ArcHUD.isClassicTbc or ArcHUD.isClassicWrath
 ArcHUD.UnitCastingInfo = UnitCastingInfo
 ArcHUD.UnitChannelInfo = UnitChannelInfo
 
@@ -150,12 +151,12 @@ end
 -- Set debug level
 ----------------------------------------------
 function ArcHUD:SetDebugLevel(level)
-	if (level == nil) or (level >= 0 and level < 4) then
+	if (level == nil) or (level > 0 and level <= 4) then
 		local levelName = "off"
 		if (level ~= nil) then
 			levelName = debugLevels[level]
+			self:Printf(L["CMD_OPTS_DEBUG_SET"], levelName)
 		end
-		self:Printf(L["CMD_OPTS_DEBUG_SET"], levelName)
 		self.db.global.debugLevel = level
 	else
 		self:Print("Invalid debug level: "..level)

--- a/Rings/Health.lua
+++ b/Rings/Health.lua
@@ -176,6 +176,7 @@ function module:OnModuleEnable()
 
 	-- Register the events we will use
 	self:RegisterUnitEvent("UNIT_HEALTH", "UpdateHealth")
+	self:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", "UpdateHealth")
 	self:RegisterUnitEvent("UNIT_MAXHEALTH", "UpdateHealth")
 	if (not ArcHUD.classic) then
 		self:RegisterUnitEvent("UNIT_HEAL_PREDICTION", "UpdateHealthPrediction")

--- a/Rings/TargetCasting.lua
+++ b/Rings/TargetCasting.lua
@@ -134,7 +134,7 @@ function module:OnModuleEnable()
 		self:RegisterUnitEvent("UNIT_SPELLCAST_DELAYED")
 		self:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_START")
 		self:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_UPDATE")
-		if not (ArcHUD.isClassicWoW or ArcHUD.isClassicTbc) then
+		if not (ArcHUD.classic) then
 			self:RegisterUnitEvent("UNIT_SPELLCAST_INTERRUPTIBLE")
 			self:RegisterUnitEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE")
 		end


### PR DESCRIPTION
- General fixes for Wrath Classic
- Fixed not being able to set debug level to warn or off
- Fix mentioned in comments of [another open issue](https://github.com/nyyr/ArcHUD3/issues/60)

NOT included: Death Knight Runes for Wrath Classic. I did implement this, but in [another branch](https://github.com/adavis9592/ArcHUD3/tree/classic-wotlk-runes). I kept this separate because while it works fine, it lacks support for custom colors, sorting runes, etc, which you may want to add first. I created this mostly by mashing up the retail Runes and RunesOld from pre-7.0.