### PR TITLE
Use number instead of constant when checking for druid form

### DIFF
--- a/Rings/ComboPointsDruid.lua
+++ b/Rings/ComboPointsDruid.lua
@@ -62,5 +62,6 @@ end
 --
 function module:CheckVisible()
 	local formId = GetShapeshiftFormID()
-	return formId == CAT_FORM
+	-- 1 for CAT_FORM
+	return formId == 1
 end


### PR DESCRIPTION
Fix the missing druid combo points